### PR TITLE
add MANIFEST.in to include predatory_journals.json

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include is_this_journal_predatory/predatory_journals.json


### PR DESCRIPTION
This should close #2 

According to Stack Overflow, a MANIFEST.in file is needed when using include_package_data=True as a parameter in setup.py.

https://stackoverflow.com/questions/2968701/2-techniques-for-including-files-in-a-python-distribution-which-is-better/2969087#2969087